### PR TITLE
Store cache as gzipped JSON in S3 cache storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     # Install Poetry
     curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/ && \
-    poetry config virtualenvs.create false
+    ln -s /root/.local/bin/poetry /usr/local/bin/
 
 # Install poetry packages
 WORKDIR /var/myapp

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -6,8 +6,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     # Install Poetry
     curl -sSL https://install.python-poetry.org | python3 - && \
-    ln -s /root/.local/bin/poetry /usr/local/bin/ && \
-    poetry config virtualenvs.create false
+    ln -s /root/.local/bin/poetry /usr/local/bin/
 
 # Install poetry packages
 WORKDIR /var/myapp

--- a/boatrace_crawler/middlewares.py
+++ b/boatrace_crawler/middlewares.py
@@ -11,7 +11,6 @@ import json
 from pathlib import Path
 
 import boto3
-import joblib
 from botocore.exceptions import ClientError
 from scrapy.http import Headers
 from scrapy.responsetypes import responsetypes
@@ -29,17 +28,6 @@ class S3Client:
         self.s3_bucket_obj = self.s3_client.Bucket(self.s3_bucket)
         if not self.s3_bucket_obj.creation_date:
             self.s3_bucket_obj.create()
-
-    def get_joblib(self, key):
-        data_bytes = self.get_bytes(key)
-
-        if data_bytes is not None:
-            with io.BytesIO(data_bytes) as b:
-                data = joblib.load(b)
-        else:
-            data = None
-
-        return data
 
     def get_json_gz(self, key):
         data_bytes = self.get_bytes(key)
@@ -67,11 +55,6 @@ class S3Client:
                 raise err
 
         return data_bytes
-
-    def put_joblib(self, key, data):
-        with io.BytesIO() as b:
-            joblib.dump(data, b, compress=True)
-            self.s3_bucket_obj.Object(key).put(Body=b.getvalue())
 
     def put_json_gz(self, key, data):
         payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
@@ -129,20 +112,13 @@ class S3CacheStorage:
 
         data = self.s3_client.get_json_gz(rpath + ".json.gz")
         if data is None:
-            spider.logger.debug("#retrieve_response: json cache not found")
-            data = self.s3_client.get_joblib(rpath + ".joblib")
-        if data is None:
             spider.logger.debug("#retrieve_response: cache not found")
             return
 
         url = data["response"]["url"]
         status = data["response"]["status"]
-        if "body_b64" in data["response"]:
-            headers = self._decode_headers(data["response"]["headers"])
-            body = self._decode_bytes(data["response"]["body_b64"])
-        else:
-            headers = Headers(data["response"]["headers"])
-            body = data["response"]["body"]
+        headers = self._decode_headers(data["response"]["headers"])
+        body = self._decode_bytes(data["response"]["body_b64"])
         respcls = responsetypes.from_args(headers=headers, url=url)
         response = respcls(url=url, headers=headers, status=status, body=body)
 

--- a/boatrace_crawler/middlewares.py
+++ b/boatrace_crawler/middlewares.py
@@ -29,7 +29,7 @@ class S3Client:
         if not self.s3_bucket_obj.creation_date:
             self.s3_bucket_obj.create()
 
-    def get_json_gz(self, key):
+    def get(self, key):
         data_bytes = self.get_bytes(key)
 
         if data_bytes is None:
@@ -56,7 +56,7 @@ class S3Client:
 
         return data_bytes
 
-    def put_json_gz(self, key, data):
+    def put(self, key, data):
         payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
         compressed = gzip.compress(payload)
         self.s3_bucket_obj.Object(key).put(Body=compressed)
@@ -110,7 +110,7 @@ class S3CacheStorage:
         rpath = self._get_request_path(spider, request)
         spider.logger.debug(f"#retrieve_response: cache path={rpath}")
 
-        data = self.s3_client.get_json_gz(rpath + ".json.gz")
+        data = self.s3_client.get(rpath + ".json.gz")
         if data is None:
             spider.logger.debug("#retrieve_response: cache not found")
             return
@@ -147,7 +147,7 @@ class S3CacheStorage:
             },
         }
 
-        self.s3_client.put_json_gz(rpath + ".json.gz", data)
+        self.s3_client.put(rpath + ".json.gz", data)
 
     def _get_request_path(self, spider, request):
         key = self._fingerprinter.fingerprint(request).hex()

--- a/boatrace_crawler/middlewares.py
+++ b/boatrace_crawler/middlewares.py
@@ -4,7 +4,10 @@
 # https://docs.scrapy.org/en/latest/topics/spider-middleware.html
 
 
+import base64
+import gzip
 import io
+import json
 from pathlib import Path
 
 import boto3
@@ -27,7 +30,7 @@ class S3Client:
         if not self.s3_bucket_obj.creation_date:
             self.s3_bucket_obj.create()
 
-    def get(self, key):
+    def get_joblib(self, key):
         data_bytes = self.get_bytes(key)
 
         if data_bytes is not None:
@@ -37,6 +40,20 @@ class S3Client:
             data = None
 
         return data
+
+    def get_json_gz(self, key):
+        data_bytes = self.get_bytes(key)
+
+        if data_bytes is None:
+            return None
+
+        with io.BytesIO(data_bytes) as b:
+            try:
+                decompressed = gzip.decompress(b.getvalue())
+            except OSError as err:
+                raise ValueError(f"Failed to decompress gzip data for key={key}") from err
+
+        return json.loads(decompressed.decode("utf-8"))
 
     def get_bytes(self, key):
         s3_obj = self.s3_bucket_obj.Object(key)
@@ -51,10 +68,15 @@ class S3Client:
 
         return data_bytes
 
-    def put(self, key, data):
+    def put_joblib(self, key, data):
         with io.BytesIO() as b:
             joblib.dump(data, b, compress=True)
             self.s3_bucket_obj.Object(key).put(Body=b.getvalue())
+
+    def put_json_gz(self, key, data):
+        payload = json.dumps(data, ensure_ascii=False).encode("utf-8")
+        compressed = gzip.compress(payload)
+        self.s3_bucket_obj.Object(key).put(Body=compressed)
 
     def put_bytes(self, key, data_bytes):
         self.s3_bucket_obj.Object(key).put(Body=data_bytes)
@@ -77,6 +99,18 @@ class S3CacheStorage:
     def close_spider(self, spider):
         pass
 
+    def _encode_bytes(self, value):
+        return base64.b64encode(value).decode("ascii")
+
+    def _decode_bytes(self, value):
+        return base64.b64decode(value.encode("ascii"))
+
+    def _encode_headers(self, headers):
+        return Headers(headers).to_unicode_dict()
+
+    def _decode_headers(self, headers):
+        return Headers(headers)
+
     def retrieve_response(self, spider, request):
         spider.logger.debug(f"#retrieve_response: start: url={request.url}")
 
@@ -93,15 +127,22 @@ class S3CacheStorage:
         rpath = self._get_request_path(spider, request)
         spider.logger.debug(f"#retrieve_response: cache path={rpath}")
 
-        data = self.s3_client.get(rpath + ".joblib")
+        data = self.s3_client.get_json_gz(rpath + ".json.gz")
+        if data is None:
+            spider.logger.debug("#retrieve_response: json cache not found")
+            data = self.s3_client.get_joblib(rpath + ".joblib")
         if data is None:
             spider.logger.debug("#retrieve_response: cache not found")
             return
 
         url = data["response"]["url"]
         status = data["response"]["status"]
-        headers = Headers(data["response"]["headers"])
-        body = data["response"]["body"]
+        if "body_b64" in data["response"]:
+            headers = self._decode_headers(data["response"]["headers"])
+            body = self._decode_bytes(data["response"]["body_b64"])
+        else:
+            headers = Headers(data["response"]["headers"])
+            body = data["response"]["body"]
         respcls = responsetypes.from_args(headers=headers, url=url)
         response = respcls(url=url, headers=headers, status=status, body=body)
 
@@ -119,18 +160,18 @@ class S3CacheStorage:
             "request": {
                 "url": request.url,
                 "method": request.method,
-                "headers": request.headers,
-                "body": request.body,
+                "headers": self._encode_headers(request.headers),
+                "body_b64": self._encode_bytes(request.body),
             },
             "response": {
                 "url": response.url,
                 "status": response.status,
-                "headers": response.headers,
-                "body": response.body,
+                "headers": self._encode_headers(response.headers),
+                "body_b64": self._encode_bytes(response.body),
             },
         }
 
-        self.s3_client.put(rpath + ".joblib", data)
+        self.s3_client.put_json_gz(rpath + ".json.gz", data)
 
     def _get_request_path(self, spider, request):
         key = self._fingerprinter.fingerprint(request).hex()


### PR DESCRIPTION
### Motivation

- Move cache serialization away from `joblib` to a portable gzipped JSON format for easier inspection and cross-language compatibility.
- Preserve backward compatibility by falling back to the existing `joblib` format when `.json.gz` is not present.
- Ensure binary response/request bodies remain safe inside JSON by encoding them as base64, and normalize headers for stable storage.

### Description

- Added `get_json_gz` and `put_json_gz` helpers to `S3Client` to read/write gzipped JSON and added gzip/JSON/base64 support and error handling for decompression failures.
- Renamed the previous `get`/`put` joblib helpers to `get_joblib`/`put_joblib` and kept them as a fallback for older caches.
- Updated `S3CacheStorage` to encode request/response bodies as base64 (`body_b64`) and to normalize headers via `_encode_headers`/`_decode_headers` and `_encode_bytes`/`_decode_bytes` helpers.
- Changed storage keys to use `*.json.gz` and implemented a fallback read to `*.joblib` when the JSON gzip cache is absent.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a17c81a8833393a31ef867bba80a)